### PR TITLE
Add cli and env lookups to yaml

### DIFF
--- a/devopsdriver/settings.py
+++ b/devopsdriver/settings.py
@@ -147,8 +147,10 @@ class Settings:
         """Sets a command line switch to map to a settings value.
 
         Args:
-            name (str): Name of the command line switch, eg '-p' or '--path'
             key (str): The settings key it maps to, dotted for inside dictionary
+            name (str): Name of the command line switch, eg '-p' or '--path'
+                            If name is not specified, the key is a settings value
+                            to lookup up the mappings for keys to switches
 
         Returns:
             Settings: Returns self so you can chain calls
@@ -165,8 +167,10 @@ class Settings:
         """Sets an environment variable to map to a settings value.
 
         Args:
-            name (str): Name of the environment variable
             key (str): The settings key it maps to, dotted for inside dictionary
+            name (str): Name of the environment variable
+                            If name is not specified, the key is a settings value
+                            to lookup up the mappings for keys to environment names
 
         Returns:
             Settings: Returns self so you can chain calls

--- a/devopsdriver/settings.py
+++ b/devopsdriver/settings.py
@@ -143,7 +143,7 @@ class Settings:
         self.opts = {}
         self.environ = {}
 
-    def cli(self, name: str, key: str):
+    def cli(self, key: str, name: str = None):
         """Sets a command line switch to map to a settings value.
 
         Args:
@@ -153,10 +153,15 @@ class Settings:
         Returns:
             Settings: Returns self so you can chain calls
         """
+        if name is None:
+            for setting_key, env_name in self.settings.get(key, {}).items():
+                self.opts[setting_key] = env_name
+            return self
+
         self.opts[key] = name
         return self
 
-    def env(self, name: str, key: str):
+    def env(self, key: str, name: str = None):
         """Sets an environment variable to map to a settings value.
 
         Args:
@@ -166,6 +171,11 @@ class Settings:
         Returns:
             Settings: Returns self so you can chain calls
         """
+        if name is None:
+            for setting_key, cli_name in self.settings.get(key, {}).items():
+                self.environ[setting_key] = cli_name
+            return self
+
         self.environ[key] = name
         return self
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -220,7 +220,7 @@ def test_cli_env_in_yaml():
         __write(
             join(base_dir, "test.yml"),
             env={"zz": "zeta"},
-            cli={"dd": "delta"},
+            cli={"dd": "--delta"},
             zz="test zz",
             dd="test dd",
         )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -128,10 +128,10 @@ def test_basic():
                 settings.Settings(
                     join(base_dir, "main.py"), dir1, dir2, aa=1, bb=2, cc=3
                 )
-                .cli("--beta", "bb")
-                .cli("--zeta", "zz")
-                .env("alpha", "aa")
-                .env("yota", "yy")
+                .cli("bb", "--beta")
+                .cli("zz", "--zeta")
+                .env("aa", "alpha")
+                .env("yy", "yota")
             )
             ltr = {"Linux": "l", "Darwin": "m", "Windows": "w", "Unknown": "l"}
             assert opts["yy"] == "yyenviron", opts["yy"]
@@ -198,5 +198,59 @@ def test_basic():
                 pass
 
 
+def test_cli_env_in_yaml():
+    """test setting cli and env lookups in the yaml itself"""
+    with TemporaryDirectory() as working_dir:
+        base_dir = join(working_dir, "base")
+        __setup_settings(
+            os="Linux",
+            shared="test",
+            Linux=join(base_dir, "Linux"),
+            Darwin=join(base_dir, "macOS"),
+            Windows=join(base_dir, "Windows"),
+        )
+        __write(
+            join(base_dir, "main.yml"),
+            env={"aa": "alpha", "yy": "yota"},
+            cli={"bb": "--beta"},
+            yy="main yy",
+            aa="main aa",
+            bb="main bb",
+        )
+        __write(
+            join(base_dir, "test.yml"),
+            env={"zz": "zeta"},
+            cli={"dd": "delta"},
+            zz="test zz",
+            dd="test dd",
+        )
+        settings.ENVIRON = {
+            "alpha": "environ aa",
+            "yota": "environ yy",
+            "zeta": "environ zz",
+            "delta": "environ dd",
+        }
+        settings.ARGV = [
+            "exe",
+            "--beta",
+            "cli bb",
+            "--zeta",
+            "cli zz",
+            "--delta",
+            "cli dd",
+        ]
+        opts = (
+            settings.Settings(join(base_dir, "main.py"), aa="code aa")
+            .cli("cli")
+            .env("env")
+        )
+        assert opts["aa"] == "code aa", opts["aa"]
+        assert opts["bb"] == "cli bb", opts["bb"]
+        assert opts["dd"] == "cli dd", opts["dd"]
+        assert opts["yy"] == "environ yy", opts["yy"]
+        assert opts["zz"] == "environ zz", opts["zz"]
+
+
 if __name__ == "__main__":
+    test_cli_env_in_yaml()
     test_basic()


### PR DESCRIPTION
You can now specify a yaml variable that holds all your command line switch and environment mappings