### PR TITLE
Adding keychain support

### DIFF
--- a/devopsdriver.yml
+++ b/devopsdriver.yml
@@ -7,3 +7,6 @@ pypi_prod:
     repo: pypi
     username: __token__
     url: https://pypi.org/simple/
+
+secrets:
+    azure.token: azure/token

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dynamic = ["version"]
 requires-python = ">= 3.10"
 dependencies = [
   "PyYAML==6.0.1",
+  "keyring==25.0.0",
 ]
 keywords = ["azure", "devops", "jira", "confluence", "email", "pipelines", "tools"]
 classifiers=[


### PR DESCRIPTION
Add keychain support.

If you map your settings to keychain via a top-level `secrets` field, then you can set your keychain passwords via `python -m devopsdriver.settings --set_secrets`

Closes #23