### PR TITLE
Use pyproject.toml to declare infrastructure dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,17 @@ authors = [
   {name = "Marc Page", email = "marcallenpage@gmail.com"},
 ]
 
+[project.optional-dependencies]
+dev = [
+    "black>=24.3.0",
+    "pylint>=3.1.0",
+]
+test = [
+    "pytest>=8.1.1",
+    "coverage>=7.4.4",
+]
+doc = []
+
 [project.urls]
 Homepage = "https://github.com/marcpage/devops-driver"
 Documentation = "https://github.com/marcpage/devops-driver"

--- a/requirements-infrastructure.txt
+++ b/requirements-infrastructure.txt
@@ -1,4 +1,0 @@
-black==24.3.0
-pylint==3.1.0
-pytest==8.1.1
-coverage==7.4.4


### PR DESCRIPTION
We were using requirements file for linting and testing. Now we have that all in `pyproject.toml`
Updated `Makefile` to use new optional dependencies.
Also moved some things to constants.