### PR TITLE
Any attribute that does not exist will have a value of None

### DIFF
--- a/devopsdriver/azdo/workitem/workitem.py
+++ b/devopsdriver/azdo/workitem/workitem.py
@@ -43,7 +43,7 @@ class WorkItem:  # pylint: disable=too-few-public-methods
         if "fields" in data:
             return WorkItem._parse_field(name, data["fields"])
 
-        raise AttributeError(f"'WorkItem' object has no attribute '{name}'")
+        return None
 
     class _Dict(dict):
         def __getattr__(self, name: str) -> Any:

--- a/tests/test_azure_workitem.py
+++ b/tests/test_azure_workitem.py
@@ -83,12 +83,7 @@ def test_workitem() -> None:
     assert wi.ChangedBy["displayName"] == "Edna Johnson", wi.changedBy
     assert wi.changedby.displayname == "Edna Johnson", wi.changedby.displayname
     assert wi.microsoft_vsts_common_priority == 2, wi.microsoft_vsts_common_priority
-
-    try:
-        _ = wi.not_a_field
-
-    except AttributeError as error:
-        assert "not_a_field" in str(error)
+    assert wi.not_a_field is None, wi.not_a_field
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When accessing `WorkItem` attributes that do not exist, we now return a value of None instead of raising `AttributeError`

fixes #51 