### PR TITLE
Now things that look like Azure timestamps will be returned as a datetime

### DIFF
--- a/devopsdriver/azdo/timestamp.py
+++ b/devopsdriver/azdo/timestamp.py
@@ -14,6 +14,29 @@ class Timestamp:
     US_PER_MS = 1000  # microseconds per millisecond
     US_PER_SEC = 1000 * US_PER_MS  # microseconds per second
 
+    @staticmethod
+    def is_timestamp(value: any) -> bool:
+        """Determines if the value is a timestamp string
+
+        Args:
+            value (any): The value to check
+
+        Returns:
+            bool: True if the value is an Azure timestamp
+        """
+        if not isinstance(value, str):
+            return False
+
+        if not value.endswith("Z"):
+            return False
+
+        try:
+            Timestamp.__parse_string(value)
+            return True
+
+        except ValueError:
+            return False
+
     def __init__(self, value: datetime | str | float | int):
         if isinstance(value, datetime):
             self.value = value

--- a/devopsdriver/azdo/workitem/workitem.py
+++ b/devopsdriver/azdo/workitem/workitem.py
@@ -3,7 +3,10 @@
 """ An Azure Devops WorkItem """
 
 from typing import Any
+
 from azure.devops.v7_1.work_item_tracking.models import WorkItem as AzureWorkItem
+
+from devopsdriver.azdo.timestamp import Timestamp
 
 
 class WorkItem:  # pylint: disable=too-few-public-methods
@@ -47,7 +50,17 @@ class WorkItem:  # pylint: disable=too-few-public-methods
 
     class _Dict(dict):
         def __getattr__(self, name: str) -> Any:
-            return WorkItem._parse_field(name, self)
+            value = WorkItem._parse_field(name, self)
+
+            if Timestamp.is_timestamp(value):
+                return Timestamp(value)
+
+            return value
 
     def __getattr__(self, name: str) -> Any:
-        return WorkItem._parse_field(name, self.raw.as_dict())
+        value = WorkItem._parse_field(name, self.raw.as_dict())
+
+        if Timestamp.is_timestamp(value):
+            return Timestamp(value)
+
+        return value

--- a/tests/test_azure_workitem.py
+++ b/tests/test_azure_workitem.py
@@ -21,7 +21,7 @@ class MockAzureWorkItem:
                 "System.Reason": "New",
                 "System.CreatedDate": "2023-11-16T03:12:32.94Z",
                 "System.CreatedBy": {
-                    "displayName": "Edna Johnson",
+                    "displayName": "Edna Johnson Z",
                     "url": "https://spsprodcus5.vssps.visualstudio.com/"
                     + "A3eb27a26-75f2-40f9-87dc-cc10e8e565e4/_apis/Identities"
                     + "/45fcf770-0670-69d4-8e48-3ae6e0bf9b5c",
@@ -40,7 +40,8 @@ class MockAzureWorkItem:
                 },
                 "System.ChangedDate": "2023-11-16T03:12:32.94Z",
                 "System.ChangedBy": {
-                    "displayName": "Edna Johnson",
+                    "displayName": "Edna Johnson .Z",
+                    "changedOn": "2023-11-16T03:12:32.94Z",
                     "url": "https://spsprodcus5.vssps.visualstudio.com/"
                     + "A3eb27a26-75f2-40f9-87dc-cc10e8e565e4/_apis/Identities/"
                     + "45fcf770-0670-69d4-8e48-3ae6e0bf9b5c",
@@ -60,7 +61,7 @@ class MockAzureWorkItem:
                 "System.CommentCount": 0,
                 "System.TeamProject": "Creative",
                 "System.AreaPath": "Creative",
-                "System.IterationPath": "Creative\\November 2 2023",
+                "System.IterationPath": "2023-11-16T03:12:32.alphaZ",
                 "System.Title": "test",
                 "Microsoft.VSTS.Common.Priority": 2,
                 "Microsoft.VSTS.Common.ValueArea": "Business",
@@ -80,11 +81,24 @@ def test_workitem() -> None:
     assert wi.ID == 5, wi.ID
     assert wi.workitemtype == "User Story", wi.workitemtype
     assert wi.system_workitemtype == "User Story", wi.system_workitemtype
-    assert wi.ChangedBy["displayName"] == "Edna Johnson", wi.changedBy
-    assert wi.changedby.displayname == "Edna Johnson", wi.changedby.displayname
     assert wi.microsoft_vsts_common_priority == 2, wi.microsoft_vsts_common_priority
     assert wi.not_a_field is None, wi.not_a_field
 
 
+def test_timestamp() -> None:
+    """test timestamps"""
+    wi = WorkItem(MockAzureWorkItem())
+    assert wi.StateChangeDate.to_string() == "2023-11-16T03:12:32.94Z"
+    assert wi.CreatedDate.to_string() == "2023-11-16T03:12:32.94Z"
+    assert wi.ChangedDate.to_string() == "2023-11-16T03:12:32.94Z"
+    assert wi.IterationPath == "2023-11-16T03:12:32.alphaZ", wi.IterationPath
+    assert wi.ChangedBy["displayName"] == "Edna Johnson .Z", wi.changedBy["displayName"]
+    assert wi.createdBy.displayName == "Edna Johnson Z", wi.createdBy.displayName
+    assert (
+        wi.changedBy.changedOn.to_string() == "2023-11-16T03:12:32.94Z"
+    ), wi.changedBy.changedOn
+
+
 if __name__ == "__main__":
+    test_timestamp()
     test_workitem()


### PR DESCRIPTION
To make it easier to handle date/time stamps, return a `Timestamp` object (that has an attribute `value` of type `datetime`)

fixes #50 