### PR TITLE
Fix warning when running settings

### DIFF
--- a/devopsdriver/__init__.py
+++ b/devopsdriver/__init__.py
@@ -1,10 +1,5 @@
 """ DevOps tools """
 
-from .azdo import Azure
-from .settings import Settings
-from .sendmail import send_email
-from .template import Template
-
 __version__ = "0.1.37"
 __author__ = "Marc Page"
 __credits__ = ""

--- a/devopsdriver/azdo/__init__.py
+++ b/devopsdriver/azdo/__init__.py
@@ -4,7 +4,7 @@
 from .clients import Azure
 from .timestamp import Timestamp
 
-from .workitem import WorkItem
+from .workitem.workitem import WorkItem
 from .workitem.wiql import Wiql, Value, Field
 from .workitem.wiql import Ascending, Descending, And, Or
 from .workitem.wiql import Equal, NotEqual, LessThanOrEqual, GreaterThanOrEqual

--- a/devopsdriver/azdo/clients.py
+++ b/devopsdriver/azdo/clients.py
@@ -7,12 +7,15 @@ API Documented here:
 https://github.com/microsoft/azure-devops-python-api
 """
 
+
 from azure.devops.connection import Connection as AzureConnection
 from msrest.authentication import BasicAuthentication as MSBasicAuthentication
 
 from devopsdriver.settings import Settings
 from devopsdriver.azdo.workitem.client import Client as WIClient
 
+
+# for testing
 CONNECTION = AzureConnection
 AUTHENTICATION = MSBasicAuthentication
 

--- a/devopsdriver/azdo/workitem/__init__.py
+++ b/devopsdriver/azdo/workitem/__init__.py
@@ -1,4 +1,1 @@
 """ init workitem module """
-
-# Re-export symbols to make things make sense
-from .workitem import WorkItem

--- a/devopsdriver/azdo/workitem/client.py
+++ b/devopsdriver/azdo/workitem/client.py
@@ -8,7 +8,7 @@ from azure.devops.v7_1.work_item_tracking.models import Wiql as AzureWiql
 from azure.devops.v7_1.work_item_tracking.models import WorkItem as AzureWorkItem
 from azure.devops.v7_1.work_item_tracking.models import TeamContext
 from azure.devops.v7_1.work_item_tracking.models import WorkItemQueryResult
-from devopsdriver.azdo.workitem import WorkItem
+from devopsdriver.azdo.workitem.workitem import WorkItem
 from devopsdriver.azdo.workitem.wiql import Wiql
 
 

--- a/devopsdriver/azdo/workitem/client.py
+++ b/devopsdriver/azdo/workitem/client.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+
 """ Azure WorkItem Client """
+
 
 from azure.devops.v7_1.work_item_tracking.models import Wiql as AzureWiql
 from azure.devops.v7_1.work_item_tracking.models import WorkItem as AzureWorkItem

--- a/devopsdriver/azdo/workitem/wiql.py
+++ b/devopsdriver/azdo/workitem/wiql.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+
 """ Builds a WIQL query
 https://learn.microsoft.com/en-us/azure/devops/boards/queries/wiql-syntax?view=azure-devops
 

--- a/devopsdriver/azdo/workitem/workitem.py
+++ b/devopsdriver/azdo/workitem/workitem.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+
 """ An Azure Devops WorkItem """
+
 
 from typing import Any
 

--- a/devopsdriver/sendmail.py
+++ b/devopsdriver/sendmail.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 
+
 """ Ability to send emails with embedded images """
+
+
 from smtplib import SMTP as OS_SMTP, SMTP_SSL as OS_SMTP_SSL
 from email.mime.multipart import MIMEMultipart as OS_MIMEMultipart
 from email.mime.text import MIMEText as OS_MIMEText
 from email.mime.image import MIMEImage as OS_MIMEImage
 
 from devopsdriver.settings import Settings
+
 
 IMAGE_HEADERS = {".png": b"\x89PNG\r\n\x1a\n", ".jpg": b"\xff\xd8\xff"}
 

--- a/devopsdriver/settings.py
+++ b/devopsdriver/settings.py
@@ -87,6 +87,7 @@ from getpass import getpass as os_getpass
 from yaml import safe_load
 from keyring import get_password, set_password
 
+
 # for testing
 ENVIRON = os_environ
 ARGV = sys_argv

--- a/devopsdriver/template.py
+++ b/devopsdriver/template.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+
 """ Module Doc """
+
 
 from os.path import dirname, basename, splitext
 

--- a/tests/test_azure_clients.py
+++ b/tests/test_azure_clients.py
@@ -10,7 +10,7 @@ from os.path import join
 
 from helpers import setup_settings, write
 
-from devopsdriver import Azure
+from devopsdriver.azdo import Azure
 from devopsdriver.azdo import clients
 
 

--- a/tests/test_sendmail.py
+++ b/tests/test_sendmail.py
@@ -3,7 +3,7 @@
 """ Test sendmail """
 
 from devopsdriver import sendmail  # for debugging
-from devopsdriver import send_email
+from devopsdriver.sendmail import send_email
 
 
 class MockMultipart(dict):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -10,7 +10,7 @@ from itertools import product
 from helpers import setup_settings, ensure, write
 
 from devopsdriver import settings  # debug access
-from devopsdriver import Settings
+from devopsdriver.settings import Settings
 
 
 def __setup_files(directory: str, dir1: str, dir2: str) -> None:


### PR DESCRIPTION
Because we are running settings directly, we are causing problems. When we create a command line tool we should create a new script that includes settings.

fixes #47 