### PR TITLE
Add symbols to top level

### DIFF
--- a/devopsdriver/__init__.py
+++ b/devopsdriver/__init__.py
@@ -1,5 +1,11 @@
 """ DevOps tools """
 
+from .settings import Settings
+from .sendmail import send_email
+from .template import Template
+from .azdo.clients import Azure
+
+
 __version__ = "0.1.39"
 __author__ = "Marc Page"
 __credits__ = ""


### PR DESCRIPTION
Add `Settings`, `send_email`, `Template, `Azure` symbols to top-level of `devopsdriver`


resolve #64 