### PR TITLE
Shift-click to get plain text instead of markdown

### DIFF
--- a/GreaseMonkey/LinkGenerator.js
+++ b/GreaseMonkey/LinkGenerator.js
@@ -1,10 +1,11 @@
 // ==UserScript==
 // @name         Link Generator
 // @namespace    http://github.com/marcpage
-// @version      0.0.1
+// @version      0.0.2
 // @description  Add a copy-link button to many sites that has Markdown and HTML formatted links
 // @author       MarcAllenPage@gmail.com
 // @homepageURL  https://github.com/marcpage/devops-driver/main/GreaseMonkey/README.md
+// @updateURL    https://raw.githubusercontent.com/marcpage/devops-driver/main/GreaseMonkey/LinkGenerator.js
 // @downloadURL  https://raw.githubusercontent.com/marcpage/devops-driver/main/GreaseMonkey/LinkGenerator.js
 // @supportURL   https://github.com/marcpage/devops-driver/issues
 // @license      Unlicense; https://opensource.org/license/unlicense/
@@ -21,6 +22,7 @@
     // =============== Templates ===============
     const MarkdownFormat = "[{{id}}]({{url}}): {{name}}";
     const HtmlFormat = "<a href='{{url}}' target='_blank'>{{id}}</a>: {{name}}";
+    const PlainFormat = "{{id}}: {{name}}";
 
     function fill_in_template(template, mappings) {
         return template.replaceAll("{{id}}", mappings.id)
@@ -81,8 +83,8 @@
 
         button.innerText = "📋";
         button.id = "generated_link_button";
-        button.onclick = function() {
-            copyDescriptionToClipboard(getJiraInfo(), HtmlFormat, MarkdownFormat);
+        button.onclick = function(event) {
+            copyDescriptionToClipboard(getJiraInfo(), HtmlFormat, event.shiftKey ? PlainFormat : MarkdownFormat);
         }
         lastBreadCrumb.appendChild(button); // add button to end of last breadcrumb
     }

--- a/GreaseMonkey/README.md
+++ b/GreaseMonkey/README.md
@@ -8,7 +8,11 @@ Currently supported pages:
 ## Install
 
 You will need to install a GreaseMonkey browser plugin.
-The recommended GreaseMonkey plugin is [ViolentMonkey](https://violentmonkey.github.io).
+
+The recommended GreaseMonkey plugin:
+
+- **Windows**: [ViolentMonkey](https://violentmonkey.github.io)
+- **macOS**: [TamperMonkey](https://www.tampermonkey.net)
 
 Once the plugin is installed, go to the Dashboard and click the plus `+` button.
 Copy the contents of `LinkGenerator.js` into a new script.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ settings = "devopsdriver.manage_settings:main"
 [tool.setuptools.package-data]
 "*" = ["*.mako"]
 
+[tool.setuptools.packages.find]
+include = ["devopsdriver*"]
+
 [project.optional-dependencies]
 dev = [
     "black>=24.3.0",


### PR DESCRIPTION
Allow Shift-click on the clipboard button to copy plain text instead of markdown
Fixed an issue with update (or at least we'll test it with this change) 