### PR TITLE
Make generic client future resistant

### DIFF
--- a/devopsdriver/azdo/clients.py
+++ b/devopsdriver/azdo/clients.py
@@ -24,6 +24,10 @@ AUTHENTICATION = MSBasicAuthentication
 class Azure:  # pylint: disable=too-few-public-methods,too-many-instance-attributes
     """A connection to Azure clients"""
 
+    class _Client:
+        def __init__(self, client):
+            self.client = client
+
     def __init__(
         self, settings: Settings = None, token: str = None, url: str = None, **clients
     ):
@@ -53,11 +57,11 @@ class Azure:  # pylint: disable=too-few-public-methods,too-many-instance-attribu
         assert not unsupported_clients, f"{unsupported_clients} not supported"
         self.workitem = WIClient(Azure.__client("workitem", clients, client_calls))
         self.pipeline = PLClient(Azure.__client("pipeline", clients, client_calls))
-        self._core = Azure.__client("core", clients, client_calls)
-        self._task = Azure.__client("task", clients, client_calls)
-        self._git = Azure.__client("git", clients, client_calls)
-        self._build = Azure.__client("build", clients, client_calls)
-        self._identity = Azure.__client("identity", clients, client_calls)
+        self.core = Azure._Client(Azure.__client("core", clients, client_calls))
+        self.task = Azure._Client(Azure.__client("task", clients, client_calls))
+        self.git = Azure._Client(Azure.__client("git", clients, client_calls))
+        self.build = Azure._Client(Azure.__client("build", clients, client_calls))
+        self.identity = Azure._Client(Azure.__client("identity", clients, client_calls))
 
     @staticmethod
     def __client(name: str, clients: dict, calls: dict) -> any:


### PR DESCRIPTION
We added a bunch of clients without wrappers. This allows for wrappers to be added without breaking client code (assuming that future wrappers set the `client` member