### PR TITLE
Coverage in README.md is now automated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ $(FORMAT_FILE): $(VENV_DIR)/touchfile $(SOURCES)
 
 format: $(FORMAT_FILE)
 	@cat $^
+	@perl -i -pe's/test\+coverage\&message=..%/test\+coverage\&message=$(MIN_TEST_COVERAGE)%/g' README.md
 
 $(LINT_FILE): $(VENV_DIR)/touchfile $(SOURCES)
 	@$(SET_ENV); $(PIP_INSTALL) ".[dev]"


### PR DESCRIPTION
Now when you update the test coverage in the `Makefile`, run `make format` and it will update the test coverage in the `READMD.md` as well.